### PR TITLE
Return the session id directly

### DIFF
--- a/js/searsia.js
+++ b/js/searsia.js
@@ -746,6 +746,7 @@ var searsia = (function () {
       timeout: 10000,
       dataType: 'json'
     })
+    return sessionid
   }
 
   /* connect to mother and return definition */
@@ -816,7 +817,7 @@ var searsia = (function () {
       connectToServer(callbackConnect)
     },
     searchFederated: function (params, callbackSearch) {
-      searchFederated(params, callbackSearch)
+      return searchFederated(params, callbackSearch)
     }
   }
 })()


### PR DESCRIPTION
If searchFederated is called twice quickly, the 'start' events for both searches may arrive out of order, so you still can't know which events belong to the last call to searchFederated. By returning the session id directly from searchFederated, we can ignore incoming events having a different (old) session id.